### PR TITLE
Support a shebang

### DIFF
--- a/build.teak
+++ b/build.teak
@@ -1,3 +1,5 @@
+#!/usr/bin/env teak
+
 bool debug #option;
 bool runTests #option;
 bool skipLibraries #option;

--- a/teak.c
+++ b/teak.c
@@ -745,6 +745,12 @@ Token TokenNext(Tokenizer *tokenizer) {
 			}
 
 			continue;
+		} else if (tokenizer->line == 1 && c == '#' && c1 == '!') {
+			while (tokenizer->position != tokenizer->inputBytes && tokenizer->input[tokenizer->position] != '\n') {
+				tokenizer->position++;
+			}
+
+			continue;
 		}
 
 		else if (c == '<' && c1 == '=' && (tokenizer->position += 2)) token.type = T_LT_OR_EQUAL;


### PR DESCRIPTION
This PR makes it possible to define a [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) on line 1 (e.g. `#!/usr/bin/env teak`) to execute scripts without calling teak explicitly.

`./build.teak` 